### PR TITLE
Änderung der Menüführung zur Nachvollziehbarkeit

### DIFF
--- a/luftfilterbegehren/templates/layout.html
+++ b/luftfilterbegehren/templates/layout.html
@@ -12,9 +12,9 @@
                 </a>
                 <nav>
                     {% set navigation_items = [
-                        ("general.share", "Werde aktiv!"),
+                        ("general.share", "Weitersagen!"),
                         ("general.supporters", "Unterstützt von"),
-                        ("general.cities", "Gemeinden"),
+                        ("general.cities", "Gemeinden anschreiben"),
                         ("general.faq", "FAQ")] %}
                     <ul class="row">
                         {% for func, title in navigation_items -%}
@@ -37,4 +37,3 @@
         {% include '_foot.html' %}
     </body>
 </html>
-


### PR DESCRIPTION
Die Menüführung war nicht Nachvollziehbar, daher wurde "Werde aktiv" -> "Weitersagen" und "Gemeinden" zu "Gemeinden anschreiben" in der Menüführung geändert.